### PR TITLE
Fix expected header name

### DIFF
--- a/fixed-price-subscriptions/server/node/server.js
+++ b/fixed-price-subscriptions/server/node/server.js
@@ -203,7 +203,7 @@ app.post(
     try {
       event = stripe.webhooks.constructEvent(
         req.body,
-        req.headers['stripe-signature'],
+        req.headers['Stripe-Signature'],
         process.env.STRIPE_WEBHOOK_SECRET
       );
     } catch (err) {


### PR DESCRIPTION
The header being sent from the Stripe test harness has capitalised words